### PR TITLE
added robotconstants.gettelemetry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ def deployArtifact = deploy.targets.roborio.artifacts.frcJava
 wpi.java.debugJni = false
 
 // Set this to true to enable desktop support.
-def includeDesktopSupport = false
+def includeDesktopSupport = true
 
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.

--- a/src/main/java/frc/robot/subsystems/shooterSubsystem/FlywheelSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooterSubsystem/FlywheelSubsystem.java
@@ -8,6 +8,7 @@ import edu.wpi.first.math.Pair;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.subsystems.shooterSubsystem.ShooterConstants.FlyWheelConstants;
+import frc.robot.utils.RobotConstants;
 import yams.mechanisms.config.FlyWheelConfig;
 import yams.mechanisms.velocity.FlyWheel;
 import yams.motorcontrollers.SmartMotorController;
@@ -44,7 +45,7 @@ public class FlywheelSubsystem extends SubsystemBase {
             .withClosedLoopRampRate(FlyWheelConstants.RAMP_RATE)
             .withOpenLoopRampRate(FlyWheelConstants.RAMP_RATE)
             .withFollowers(new Pair<>(followerMotor, true))
-            .withTelemetry("ShooterMotor", TelemetryVerbosity.LOW);
+            .withTelemetry("ShooterMotor", RobotConstants.GetTelemetry());
 
     private final SmartMotorController motor = new TalonFXWrapper(
             flywheelMotor,
@@ -56,7 +57,7 @@ public class FlywheelSubsystem extends SubsystemBase {
             .withMass(FlyWheelConstants.WHEEL_MASS)
             .withLowerSoftLimit(FlyWheelConstants.MIN_VELOCITY)
             .withUpperSoftLimit(FlyWheelConstants.MAX_VELOCITY)
-            .withTelemetry("Shooter", TelemetryVerbosity.LOW);
+            .withTelemetry("Shooter", RobotConstants.GetTelemetry());
 
     private final FlyWheel flywheel = new FlyWheel(flywheelConfig);
 

--- a/src/main/java/frc/robot/subsystems/shooterSubsystem/Hood.java
+++ b/src/main/java/frc/robot/subsystems/shooterSubsystem/Hood.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.subsystems.shooterSubsystem.ShooterConstants.HoodConstants;
+import frc.robot.utils.RobotConstants;
 import yams.mechanisms.config.PivotConfig;
 import yams.mechanisms.positional.Pivot;
 import yams.motorcontrollers.SmartMotorController;
@@ -55,7 +56,7 @@ public class Hood extends SubsystemBase {
             .withIdleMode(MotorMode.BRAKE)
             .withStatorCurrentLimit(HoodConstants.STATOR_LIMIT)
             .withClosedLoopRampRate(HoodConstants.RAMP_RATE)
-            .withTelemetry("HoodMotor", TelemetryVerbosity.LOW);
+            .withTelemetry("HoodMotor", RobotConstants.GetTelemetry());
 
     private final SmartMotorController motor = new TalonFXWrapper(
         hoodMotor,
@@ -68,7 +69,7 @@ public class Hood extends SubsystemBase {
         .withHardLimit(HoodConstants.MIN_ANGLE, HoodConstants.MAX_ANGLE)
         .withSoftLimits(HoodConstants.MIN_ANGLE, HoodConstants.MAX_ANGLE)
         .withMOI(HoodConstants.MOI_LENGTH, HoodConstants.MOI_MASS)
-        .withTelemetry("Hood", TelemetryVerbosity.LOW);
+        .withTelemetry("Hood", RobotConstants.GetTelemetry());
 
     private final Pivot hood = new Pivot(hoodConfig);
 

--- a/src/main/java/frc/robot/subsystems/shooterSubsystem/ShooterConstants.java
+++ b/src/main/java/frc/robot/subsystems/shooterSubsystem/ShooterConstants.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems.shooterSubsystem;
 
 import static edu.wpi.first.units.Units.*;
 
+
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -109,6 +110,13 @@ public class ShooterConstants {
         public static final double kV = 0.12;
         public static final double kA = 0.0;
 
+        public static final double kP_SIM = 50.0;
+        public static final double kI_SIM = 0.0;
+        public static final double kD_SIM = 2.0;
+        public static final double kS_SIM = 0.0;
+        public static final double kV_SIM = 0.12;
+        public static final double kA_SIM = 0.0;
+
         public static final AngularVelocity MAX_VEL = DegreesPerSecond.of(180);
         public static final AngularAcceleration MAX_ACCEL =
             DegreesPerSecondPerSecond.of(360);
@@ -117,5 +125,8 @@ public class ShooterConstants {
 
         public static final SimpleMotorFeedforward FEEDFORWARD =
             new SimpleMotorFeedforward(kS, kV, kA);
+
+            public static final SimpleMotorFeedforward FEEDFORWARD_SIM =
+            new SimpleMotorFeedforward(kS_SIM, kV_SIM, kA_SIM);
     }
 }

--- a/src/main/java/frc/robot/subsystems/shooterSubsystem/Turret.java
+++ b/src/main/java/frc/robot/subsystems/shooterSubsystem/Turret.java
@@ -7,6 +7,7 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.subsystems.shooterSubsystem.ShooterConstants.TurretConstants;
+import frc.robot.utils.RobotConstants;
 import yams.mechanisms.config.PivotConfig;
 import yams.mechanisms.positional.Pivot;
 import yams.motorcontrollers.SmartMotorController;
@@ -30,18 +31,18 @@ public class Turret extends SubsystemBase {
             )
             .withFeedforward(TurretConstants.FEEDFORWARD)
             .withSimClosedLoopController(
-                15,
-                0,
-                2,
+                TurretConstants.kP_SIM,
+                TurretConstants.kI_SIM, 
+                TurretConstants.kD_SIM, 
                 TurretConstants.MAX_VEL,
                 TurretConstants.MAX_ACCEL
-            )
-            .withSimFeedforward(TurretConstants.FEEDFORWARD)
+                )
+            .withSimFeedforward(TurretConstants.FEEDFORWARD_SIM)
             .withGearing(TurretConstants.GEARING)
             .withIdleMode(MotorMode.BRAKE)
             .withStatorCurrentLimit(TurretConstants.STATOR_LIMIT)
             .withClosedLoopRampRate(TurretConstants.RAMP_RATE)
-            .withTelemetry("TurretMotor", TelemetryVerbosity.HIGH);
+            .withTelemetry("TurretMotor", RobotConstants.GetTelemetry());
 
     private final TalonFX turretMotor = new TalonFX(TurretConstants.MOTOR_ID);
     private final SmartMotorController motor = new TalonFXWrapper(
@@ -54,7 +55,7 @@ public class Turret extends SubsystemBase {
         .withStartingPosition(TurretConstants.STARTING_POS)
         .withHardLimit(TurretConstants.MIN_ANGLE, TurretConstants.MAX_ANGLE)
         .withSoftLimits(Degrees.of(5), Degrees.of(350))
-        .withTelemetry("Turret", TelemetryVerbosity.HIGH)
+        .withTelemetry("Turret", RobotConstants.GetTelemetry())
         .withMOI(TurretConstants.LENGTH, TurretConstants.WEIGHT);
 
     private final Pivot turret = new Pivot(turretConfig);

--- a/src/main/java/frc/robot/utils/RobotConstants.java
+++ b/src/main/java/frc/robot/utils/RobotConstants.java
@@ -1,0 +1,13 @@
+package frc.robot.utils;
+
+import edu.wpi.first.wpilibj.RobotBase;
+import yams.motorcontrollers.SmartMotorControllerConfig.TelemetryVerbosity;
+
+public class RobotConstants {
+    public static TelemetryVerbosity GetTelemetry() {
+        if (RobotBase.isSimulation()) {
+            return TelemetryVerbosity.HIGH;
+        }
+        return TelemetryVerbosity.LOW;
+    }
+}

--- a/src/main/java/frc/robot/utils/ShooterCalc.java
+++ b/src/main/java/frc/robot/utils/ShooterCalc.java
@@ -5,7 +5,10 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.*;
 import edu.wpi.first.math.interpolation.*;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.StructArrayPublisher;
 import edu.wpi.first.units.measure.*;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.subsystems.drive.CommandSwerveDrivetrain;
 import frc.robot.utils.FieldConstants.Hub;
 import frc.robot.utils.FieldConstants.LeftBump;
@@ -13,6 +16,9 @@ import frc.robot.utils.FieldConstants.LinesVertical;
 import frc.robot.utils.FieldConstants.RightBump;
 
 public class ShooterCalc {
+
+           private StructArrayPublisher<Translation2d> publisher = NetworkTableInstance.getDefault().getStructArrayTopic(
+            "ShooterCalc/Target", Translation2d.struct).publish();
 
     public record FullShooterParams(double rpm, double hood, double tof) {
         public static FullShooterParams interpolate(
@@ -126,6 +132,13 @@ public class ShooterCalc {
                 ? LeftBump.nearLeftCorner
                 : RightBump.nearRightCorner;
         }
+
+        publishTranslation(targetLogical);
+
         return AllianceFlip.apply(targetLogical);
+    }
+
+    private void publishTranslation(Translation2d loc) {
+            publisher.set(new Translation2d[] {loc});
     }
 }


### PR DESCRIPTION
Added a robot constants to check whether or not we are in sim. If we are, we can use the higher telemetry. The rio is not very powerful so we are reducing the telemetry when we are using it.

Updated some sim constants for the turret so we can tune it in advantage scope

Added the target from shooter calc onto network tables so that we can visualize it in advantages scope to make sure it is working as intended